### PR TITLE
Fix #21: Confetti Overlay over Successful Product Name

### DIFF
--- a/src/components/bildval/guessOption.tsx
+++ b/src/components/bildval/guessOption.tsx
@@ -42,8 +42,8 @@ export const BildvalGuessOption = ({
         setShowConfetti(true);
         // Play success audio
         playSuccessAudio?.();
-        // Hide Confetti with a delay of 500 ms
-        setTimeout(() => setShowConfetti(false), 500);
+        // Hide Confetti with a delay of 1500 ms
+        setTimeout(() => setShowConfetti(false), 1500);
       } else {
         // Jiggle button
         animateButton(

--- a/src/components/bildval/guessOption.tsx
+++ b/src/components/bildval/guessOption.tsx
@@ -23,7 +23,7 @@ export const BildvalGuessOption = ({
   ...props
 }: BildvalGuessOptionProps) => {
   const [isLoaded, setLoaded] = useState(false);
-  const [isSuccess, setSuccess] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
 
   const [buttonRef, animateButton] = useAnimate();
   const { playFailureAudio, playSuccessAudio } = useAudio();
@@ -39,9 +39,11 @@ export const BildvalGuessOption = ({
       // Check if correct
       if (solution?.id === guess.id) {
         // Show confetti
-        setSuccess(true);
+        setShowConfetti(true);
         // Play success audio
         playSuccessAudio?.();
+        // Hide Confetti with a delay of 500 ms
+        setTimeout(() => setShowConfetti(false), 500);
       } else {
         // Jiggle button
         animateButton(
@@ -109,7 +111,7 @@ export const BildvalGuessOption = ({
         pointerEvents="none"
         blendMode="darken"
       />
-      {isSuccess && (
+      {showConfetti && (
         <Center position="absolute" top="0" bottom="0" left="0" right="0" zIndex="2">
           <ConfettiExplosion colors={CONFETTI_COLORS} height="80vh" />
         </Center>


### PR DESCRIPTION
**Fixes**: #21 

**Description**: On making a successful guess in the Bildval game, the confetti overlay makes the product-name un-clickable.

**Solution**: This was being caused due to setting the state of the confetti to true inside the onClick handler, once the confetti is shown and the success audio is played I have added a short delay of 500 ms thereby hiding the overlay.

**Tags**: `bug`, `hacktoberfest`