### PR TITLE
Fix #41: Extra characters can be entered via the Jumble visual keyboard beyond the character limit

### DIFF
--- a/src/components/wordInput.tsx
+++ b/src/components/wordInput.tsx
@@ -89,6 +89,8 @@ export const WordInput = forwardRef<HTMLInputElement, WordInputProps>((props, in
     if (input.length > length) {
       // Jiggle input if longer than target length (feedback for extra presses)
       animateContainer(containerRef.current, { translate: [0, "-5px", 0, "5px", 0] }, { duration: 0.1, repeat: 3 });
+      // @ts-expect-error
+      keyboardRef.current?.setInput(input.slice(0, length));
       return;
     }
 


### PR DESCRIPTION
Fixes #41 

- If the input from the visual keyboard exceeds that of the allowable maximum length, the keyboard's input is truncated and set via the `setInput` method.

If you see any issues with my pull request or suggestions for improvement, please let me know.

Tags: `bug`